### PR TITLE
Thumbnail in documents

### DIFF
--- a/migrations/20210422213726-add-thumbnail-to-document.js
+++ b/migrations/20210422213726-add-thumbnail-to-document.js
@@ -1,0 +1,5 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) =>
+    queryInterface.addColumn('Documents', 'thumbnail', { type: Sequelize.TEXT }),
+  down: async queryInterface => queryInterface.removeColumn('Documents', 'thumbnail'),
+};

--- a/models/document.js
+++ b/models/document.js
@@ -16,6 +16,7 @@ module.exports = (sequelize, DataTypes) => {
       artstor: DataTypes.TEXT,
       firstyear: DataTypes.INTEGER,
       lastyear: DataTypes.INTEGER,
+      thumbnail: DataTypes.TEXT,
       VisualId: DataTypes.INTEGER,
       latitude: DataTypes.FLOAT,
       longitude: DataTypes.FLOAT,

--- a/routes/documents/documents.test.js
+++ b/routes/documents/documents.test.js
@@ -21,6 +21,7 @@ describe('test document API route', () => {
       creator: `${faker.name.firstName()} ${faker.name.lastName()}`,
       firstyear: 1900,
       lastyear: 2000,
+      thumbnail: faker.internet.url(),
       VisualId: visual.id,
       latitude: faker.datatype.float({ min: -90, max: 90 }),
       longitude: faker.datatype.float({ min: -180, max: 180 }),
@@ -53,6 +54,7 @@ describe('test document API route', () => {
           'longitude',
           'firstyear',
           'lastyear',
+          'thumbnail',
         ]),
       ],
     });

--- a/routes/documents/index.js
+++ b/routes/documents/index.js
@@ -31,7 +31,15 @@ module.exports = router => {
       where: visualWhere,
       include: {
         association: 'Documents',
-        attributes: ['ssid', 'title', 'latitude', 'longitude', 'firstyear', 'lastyear'],
+        attributes: [
+          'ssid',
+          'title',
+          'latitude',
+          'longitude',
+          'firstyear',
+          'lastyear',
+          'thumbnail',
+        ],
         where,
         include: {
           association: 'ImageMeta',

--- a/seeders/20201001123024-load-documents.js
+++ b/seeders/20201001123024-load-documents.js
@@ -31,7 +31,7 @@ module.exports = {
         .then(({ data: { features } }) => {
           console.log(`${i} / ${count}`);
           const featureLoader = features.map(feature => {
-            const ssid = `SSID${
+            const ssid = `${
               feature.properties.notes && feature.properties.notes.match(/^\d+$/)
                 ? feature.properties.notes
                 : feature.properties.ss_id


### PR DESCRIPTION
To speed up image loading, we will skip the IIIF server for thumbnails and use the ones created by Omeka. Since they don't follow a pattern based on IDs, they need to be stored in the dataase first.