### PR TITLE
Buffer reprojection

### DIFF
--- a/routes/feature/index.js
+++ b/routes/feature/index.js
@@ -30,11 +30,15 @@ module.exports = router => {
                 Sequelize.fn(
                   'ST_Buffer',
                   Sequelize.fn(
-                    'ST_SetSRID',
-                    Sequelize.fn('ST_GeomFromGeoJSON', JSON.stringify(feature.geom)),
-                    4326
+                    'ST_Transform',
+                    Sequelize.fn(
+                      'ST_SetSRID',
+                      Sequelize.fn('ST_GeomFromGeoJSON', JSON.stringify(feature.geom)),
+                      4326
+                    ),
+                    3857
                   ),
-                  0.001
+                  500
                 ),
                 Sequelize.col('geom')
               ),

--- a/routes/probe/index.js
+++ b/routes/probe/index.js
@@ -11,8 +11,12 @@ module.exports = router => {
 
     let geom = Sequelize.fn(
       'ST_Buffer',
-      Sequelize.fn('ST_SetSRID', Sequelize.fn('ST_MakePoint', ...location), 4326),
-      0.0001
+      Sequelize.fn(
+        'ST_Transform',
+        Sequelize.fn('ST_SetSRID', Sequelize.fn('ST_MakePoint', ...location), 4326),
+        3857
+      ),
+      100
     );
     if (location.length === 4) geom = Sequelize.fn('ST_MakeEnvelope', ...location, 4326);
 


### PR DESCRIPTION
Reproject buffers to 3857 before calculating intersect. Should give more accurate results and prevent a DB crash.