### PR TITLE
feat(rate-limit): bypass the rate limit with a shared token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,13 @@
 PORT=5000
 NODE_ENV=development
 LOG_LEVEL=info
+# Max API requests per minute per IP before a 429 is returned (default 300).
+RATE_LIMIT_PER_MIN=300
+# Shared secret that lets a trusted client (e.g. the imagineRio site build) skip
+# the rate limit by sending it as the `x-ratelimit-bypass` request header. Leave
+# blank to disable bypass entirely. Generate one with e.g.
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+RATE_LIMIT_BYPASS_TOKEN=
 
 # --- Database ---
 # Postgres connection string. Local dev defaults to the value below if unset.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ See `.env.example` for the full list. The most commonly missed:
 - `MAPPING` — selects the site config (e.g. `rio`); used by seeders and `utils/mapProperties.js`
 - `ARCGIS_API_KEY` — API key for the imagineRio_GDB FeatureServer; consumed by the seeders via `utils/arcgisClient.js`
 
+## Rate limiting
+
+Every request is rate limited per IP — `RATE_LIMIT_PER_MIN` requests per minute
+(default 300), after which the API returns `429`. A static build of the
+imagineRio site fans out far more than that in under a minute, so it needs a way
+around the limit.
+
+Set `RATE_LIMIT_BYPASS_TOKEN` on the API and have the build send the same value
+as the `x-ratelimit-bypass` request header. Matching requests skip the limiter
+entirely and are never counted. The comparison is constant-time, and with no
+token configured no request can bypass — the limiter is unchanged. Keep the
+token secret: anyone who has it can sidestep the limit.
+
 ## API surface
 
 All routes are GET. Wired up via `server.js` auto-loading every directory under `routes/`.

--- a/render.yaml
+++ b/render.yaml
@@ -34,6 +34,14 @@ services:
       # memory") while most of the container's RAM is still free.
       - key: NODE_OPTIONS
         value: '--max-old-space-size=384'
+      # Shared secret the imagineRio site build sends as the `x-ratelimit-bypass`
+      # header so its burst of build-time requests skips the API rate limit. The
+      # site build runs on Render too, so the cleanest way to share this is a
+      # Render env group referenced by both services (define and rotate once).
+      # Kept as `sync: false` here so the secret stays out of the blueprint —
+      # enter it in the dashboard and give the build the same value.
+      - key: RATE_LIMIT_BYPASS_TOKEN
+        sync: false
       - key: IIIF
         value: https://iiif.imaginerio.org
       - key: COLLECTIONS

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@
 require('dotenv').config();
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
@@ -14,6 +15,23 @@ const logger = require('./utils/logger');
 const { notFound, errorHandler } = require('./middleware/errorHandler');
 
 const startup = require('./startup').default;
+
+// The imagineRio site build fans out hundreds of API requests in well under a
+// minute, tripping the per-IP rate limit and filling its build log with 429s.
+// A request carrying the shared bypass token skips the limiter entirely. The
+// token is optional: with RATE_LIMIT_BYPASS_TOKEN unset, nothing can bypass,
+// so the limiter behaves exactly as it did before.
+const bypassToken = process.env.RATE_LIMIT_BYPASS_TOKEN;
+
+const hasBypassToken = req => {
+  if (!bypassToken) return false;
+  const provided = req.get('x-ratelimit-bypass');
+  if (!provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(bypassToken);
+  // timingSafeEqual throws on a length mismatch, so gate on length first.
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+};
 
 const app = express();
 
@@ -28,6 +46,7 @@ app.use(
     limit: Number(process.env.RATE_LIMIT_PER_MIN) || 300,
     standardHeaders: 'draft-7',
     legacyHeaders: false,
+    skip: hasBypassToken,
   })
 );
 

--- a/tests/rateLimit.test.js
+++ b/tests/rateLimit.test.js
@@ -1,0 +1,62 @@
+const supertest = require('supertest');
+
+// The limiter reads its config once, at require time, and each app instance
+// gets its own in-memory bucket store. So every case sets env vars, then loads
+// a fresh server in an isolated module registry — no bucket bleeds across cases.
+const loadApp = () => {
+  let app;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line global-require
+    app = require('../server');
+  });
+  return app;
+};
+
+const hit = (app, token) => {
+  const req = supertest(app).get('/health');
+  return token ? req.set('x-ratelimit-bypass', token) : req;
+};
+
+describe('rate limiting', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, RATE_LIMIT_PER_MIN: '2' };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('returns 429 once the per-minute limit is exceeded', async () => {
+    delete process.env.RATE_LIMIT_BYPASS_TOKEN;
+    const app = loadApp();
+
+    expect((await hit(app)).status).toBe(200);
+    expect((await hit(app)).status).toBe(200);
+    expect((await hit(app)).status).toBe(429);
+  });
+
+  it('never counts requests carrying the bypass token', async () => {
+    process.env.RATE_LIMIT_BYPASS_TOKEN = 'build-secret';
+    const app = loadApp();
+
+    const statuses = [];
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      statuses.push((await hit(app, 'build-secret')).status);
+    }
+    // Well past the limit of 2, every request bypassed.
+    expect(statuses).toEqual([200, 200, 200, 200, 200]);
+  });
+
+  it('still limits requests presenting the wrong token', async () => {
+    process.env.RATE_LIMIT_BYPASS_TOKEN = 'build-secret';
+    const app = loadApp();
+
+    expect((await hit(app, 'nope')).status).toBe(200);
+    expect((await hit(app, 'nope')).status).toBe(200);
+    expect((await hit(app, 'nope')).status).toBe(429);
+  });
+});


### PR DESCRIPTION
## What & why

A full static build of the imagineRio site (`imaginerioNext`) fires hundreds of requests at this API in under a minute, tripping the per-IP rate limit (`RATE_LIMIT_PER_MIN`, default 300) and failing the build with 429s.

This adds an optional **shared bypass token**. A request carrying the correct value in the `x-ratelimit-bypass` header skips the limiter entirely via `express-rate-limit`'s `skip` option.

## Design

- **Safe by default** — with `RATE_LIMIT_BYPASS_TOKEN` unset, nothing can bypass and the limiter is unchanged.
- **Constant-time comparison** (`crypto.timingSafeEqual`, length-gated) so the token isn't discoverable by timing.
- **Global** across all routes (a build hits many endpoints).

## Deploy notes

- Set `RATE_LIMIT_BYPASS_TOKEN` on the service. It is a `sync: false` secret in `render.yaml`, so **PR preview envs won't inherit it** — move it to a shared env group if you want previews (and the frontend build) to share one value.
- Pairs with the frontend PR that sends the header — deploy them together.

## Tests

`tests/rateLimit.test.js` — limit enforced (429 after the cap), valid token bypasses well past the cap, wrong/absent token still limited. `yarn jest tests/rateLimit.test.js` is green; eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
